### PR TITLE
Fix #37

### DIFF
--- a/bss.esm.js
+++ b/bss.esm.js
@@ -523,7 +523,7 @@ var stringToObject = memoize(function (string) {
   var last = ''
     , prev;
 
-  return string.trim().split(/;|\n/).reduce(function (acc, line) {
+  return string.trim().split(';').reduce(function (acc, line) {
     line = last + line.trim();
     last = line.charAt(line.length - 1) === ',' ? line : '';
     if (last)


### PR DESCRIPTION
Removed the erroneous key-value pair splitting on newlines

I'll clean this up and persist later, but essentially... [It works](https://flems.io/#0=N4IgzgpgNhDGAuEAmIBcIAW94AcyoHoCBXAOxwGsBzAOlgHsBbAgIzDAAEBGGgZhoAMrdjQBWYEABoQAMwCWMCagDaoUgENGENCDETpDUoiM7DYeAAIAMvQBeEUlQgWAvBeAAdUhYsA3ORAA7qgWABTAsBgKSABODgC+AJSuAHxePj6MoQDkNDb2jhAA6jHqODgQMdkWANQWLAAG6Rk+OPRgcvBy9KQhcVDqXb4QANzNPg2S4xlZufkOTtV1jdMtbR1dPT4h6mz0UMSIY94tGfD0OKfbFgCsAgCkIxarGTAylqchd48vPvClpDAMnoMUYFhC-3UgIGiFCAFpvpILAiHslflcMTF6PBBhB4QAWG5ICBURLHDEWQJyJDwDCfCxcAQPckYnDqJBIOSODIhAQWPmM5no9EsdSwahYshIEJQLkQdQxOFUUqchzwULonyE4lUJGaiwxKii0IAJhuSLN5tuAiRXESepOFMNxrNFpuVruSIEiXRZJeDXtLxekWicVIU0dFkDpHiXi8jBojHoZHVSHosGIWiMNBY9CQAE8kZ4Tv4giFQskXClnpGsvNCg6rrMMFxskjsgAJaBQejZaMtaNJKTgaBwTaAnQCVACOG8KcmkDxAC60llpAoSlUIA0Wh0jE6GBiCg4pAgAA94MPiDEoDosLh8EQyJRaAxmPvaUeoBwTYJBHCYlgGguAID9DwUPRh3gfMKh0MBYCPHBL3iSQ1E0bR0DYfQQGvW90HvPBCBIchqDoJhhE4Hh+CELDIOkaDYPQeDEMvaQ2XgSIIE3ZRlBtEBZXVEAV2UOEuGkAgRgAHw8LwCCEyRlDEkBshGbJ5N46REhoOJ5K4fFJC4MSuDnfEjJMrglxXEcYAQboJ3QG5eC4acEV4E1p0XJd4iAA)!